### PR TITLE
Login data was not correctly passed to aiohttp

### DIFF
--- a/custom_components/mysmartbike/webapi.py
+++ b/custom_components/mysmartbike/webapi.py
@@ -51,7 +51,7 @@ class MySmartBikeWebApi:
             return True, self.token
 
         LOGGER.debug("login: Token expired")
-        data = f"password={self._password}&contents_id=&email={self._username}"
+        data = {"password":self._password,"contents_id":"","email":self._username}
 
         headers = {"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"}
 


### PR DESCRIPTION
Since I use randomly generated passwords that include an '&', I couldn't authenticate using this integration. Logging in on the my-smartbike website and app was no problem.

The cause is the data string that is passed down to the aiohttp session. An '&' in the password (or email) would cause incorrect form encoding.

The fix is to use a dictionary instead of a format string, as aiohttp would automatically form-encode the given dictionary.  ([source](https://docs.aiohttp.org/en/stable/client_quickstart.html#more-complicated-post-requests))

